### PR TITLE
consumable notes ui polish

### DIFF
--- a/apps/web/components/account/account-information.tsx
+++ b/apps/web/components/account/account-information.tsx
@@ -7,9 +7,6 @@ import ConsumableNotesCard from "@/components/account/consumable-notes-card";
 const AccountInformation = ({ account }: { account: Account }) => {
   return (
     <div className="flex flex-col gap-8">
-      {account.consumableNoteIds.length > 0 && (
-        <ConsumableNotesCard account={account} />
-      )}
       <div className="flex flex-col gap-2">
         <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
           Account Information
@@ -36,6 +33,9 @@ const AccountInformation = ({ account }: { account: Account }) => {
         </h4>
         <AccountStorageTable storage={account.account.storage()} />
       </div>
+      {account.consumableNoteIds.length > 0 && (
+        <ConsumableNotesCard account={account} />
+      )}
     </div>
   );
 };

--- a/apps/web/components/account/account-notes-table.tsx
+++ b/apps/web/components/account/account-notes-table.tsx
@@ -69,49 +69,47 @@ const AccountNotesTable = ({ account }: { account: Account }) => {
     .map((noteId) => inputNotes.find(({ id }) => id === noteId))
     .filter((note) => note !== undefined);
   return (
-    <div className="rounded-md border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>ID</TableHead>
-            <TableHead>Script Root</TableHead>
-            <TableHead>Storage mode</TableHead>
-            <TableHead>Sender ID</TableHead>
-            <TableHead />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {consumableNotes.map((inputNote) => {
-            const type = noteType(inputNote.inputNote);
-            return (
-              <TableRow key={inputNote.id}>
-                <TableCell>
-                  <NoteId inputNote={inputNote} />
-                </TableCell>
-                <TableCell>
-                  <NoteScriptRoot inputNote={inputNote} />
-                </TableCell>
-                <TableCell>
-                  <Badge
-                    variant={type === "Public" ? "default" : "destructive"}
-                  >
-                    {type}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <AccountAddress
-                    address={noteSenderAddress(inputNote.inputNote, networkId)}
-                  />
-                </TableCell>
-                <TableCell>
-                  <NoteActionsCell account={account} noteId={inputNote.id} />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="pl-6">ID</TableHead>
+          <TableHead>Script Root</TableHead>
+          <TableHead>Storage mode</TableHead>
+          <TableHead>Sender ID</TableHead>
+          <TableHead className="pr-6" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {consumableNotes.map((inputNote) => {
+          const type = noteType(inputNote.inputNote);
+          return (
+            <TableRow key={inputNote.id}>
+              <TableCell className="pl-6">
+                <NoteId inputNote={inputNote} />
+              </TableCell>
+              <TableCell>
+                <NoteScriptRoot inputNote={inputNote} />
+              </TableCell>
+              <TableCell>
+                <Badge
+                  variant={type === "Public" ? "default" : "destructive"}
+                >
+                  {type}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <AccountAddress
+                  address={noteSenderAddress(inputNote.inputNote, networkId)}
+                />
+              </TableCell>
+              <TableCell className="pr-6">
+                <NoteActionsCell account={account} noteId={inputNote.id} />
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/apps/web/components/account/consumable-notes-card.tsx
+++ b/apps/web/components/account/consumable-notes-card.tsx
@@ -15,8 +15,8 @@ const ConsumableNotesCard = ({ account }: { account: Account }) => {
   const { openCreateTransactionDialog, newConsumeTransactionRequest } =
     useTransactions();
   return (
-    <Card>
-      <CardHeader>
+    <Card className="pb-0 gap-2">
+      <CardHeader className="">
         <CardTitle>Consumable Notes</CardTitle>
         <CardDescription>
           This account has pending notes that can be consumed.
@@ -41,7 +41,7 @@ const ConsumableNotesCard = ({ account }: { account: Account }) => {
           </Button>
         </CardAction>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-0 pt-4 rounded-b-md">
         <AccountNotesTable account={account} />
       </CardContent>
     </Card>


### PR DESCRIPTION
Tried to clean up the consumable notes card by removing unnecessary lines inside of the card.

After some consideration I also think that we would be perfectly fine to "just" use the same style as for other components within Account info, for example "Storage" and just add a horizontal line above consumable notes to differentiate it a bit from the rest of account info.