### PR TITLE
chore: remove TODO comment from use-notes hook

### DIFF
--- a/apps/web/hooks/use-notes.ts
+++ b/apps/web/hooks/use-notes.ts
@@ -15,7 +15,7 @@ import useWebClient from "@/hooks/use-web-client";
 const useNotes = () => {
   const { midenSdk } = useMidenSdk();
   const {
-    tutorialId, // TODO
+    tutorialId,
     inputNotes,
     exportNoteDialogOpen,
     importNoteDialogOpen,


### PR DESCRIPTION
Remove TODO comment for tutorialId in use-notes hook. The variable is already implemented and used in the codebase.